### PR TITLE
Improve interoperability with requested attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,28 @@ want to use a stable version of the module.
 Configuration
 -------------
 
-This module includes several authentication processing filters that can be configured as any other filter. Please read
+This module includes an authentication processing filter that can be configured as any other filter. Please read
 [the documentation](https://simplesamlphp.org/docs/stable/simplesamlphp-authproc) for more general information about
 authentication processing filters.
 
-#### 1. Entity Category
+You can define your own entity categories, and assign the attributes allowed for each of them. It accepts the following
+boolean configuration options:
 
-This filter allows you to define your own entity categories, and assign the attributes allowed for each of them. It
-accepts one single boolean configuration option named `default` to indicate that the attributes defined for each
-category should be considered the minimum set for those service providers not specifying any required attributes. The
-rest of the configuration would be `category => attributes` pairs, where *category* is the identifier of the entity
-category, and *attributes* is an array containing a list of attributes allowed for that category.
+* `default` (defaults to `false`): when set to `true` it indicates that the attributes defined for each category should
+be considered the minimum set for those service providers not specifying any required attributes.
+* `strict` (defaults to `false`): when this option is `true` and the a service provider has none of the listed
+entity categories, the module will zero out the list of releasable attributes to it. If set to `false`, the
+releasable attribute list will remain unchanged for non-matching service providers.
+* `allowRequestedAttributes` (defaults to `false`): if set to `true` the list of requested attributes in the SP metadata
+will be added to the list of allowed attributes in the entity category configuration. If `false`, the attribute
+requirements from the metadata (ie. RequestedAttributes) are ignored during the attribute release for the service
+providers that match one of the entity categories.
+
+The rest of the configuration would be `category => attributes` pairs, where *category* is the identifier of the
+entity category, and *attributes* is an array containing a list of attributes allowed for that category.
 
 For example, to allow all the services in your domain to receive *eduPersonPrincipalName* as an identifier of the user,
 tag them all with a custom category, and define the following filter:
-
 ```
     50 => array(
         'class' => 'entitycategories:EntityCategory',
@@ -63,8 +70,9 @@ in case they ask for it or they don't ask for any attributes at all:
 ```
 
 Please note that if the service asks for other attributes, not including *eduPersonPrincipalName*, **that attribute will
-not be sent**. Remember also that this filter must be used together with `core:AttributeLimit` or a similar filter.
-Therefore, after configuring the `entitycategories:EntityCategory` filter, you should also configure the former:
+not be sent**. If the service asks for some attributes but not *eduPersonPrincipalName*, **no attributes** will be sent.
+Also remember that this filter must be used together with `core:AttributeLimit` or a similar filter. Therefore, after
+configuring the `entitycategories:EntityCategory` filter, you should also configure the former:
 
 ```
     51 => array(
@@ -89,6 +97,72 @@ them in case the service doesn't ask for them, skip the `default` configuration 
     ),
 ```
 
-Now, if a service belonging to the _urn:something:local_service_ category requests the *eduPersonPrincipalName*
+Now, if a service belonging to the `urn:something:local_service` category requests the *eduPersonPrincipalName*
 attribute in the `attributes` array on its metadata, it is guaranteed to get it. If it doesn't request it (no matter
 whether it requests other attributes or not), it won't get it.
+
+The following example will release the attribute bundle defined in
+[Research and Scholarship Entity Category](https://refeds.org/category/research-and-scholarship) for SP's having
+the R&S entity category, but also the released set may be extended by additional attributes. For non-matching SP's,
+the the release rules are controlled by the metadata.
+
+```
+    50  => array(
+         'class' => 'entitycategories:EntityCategory',
+         'default' => true,
+         'strict' => false,
+         'allowRequestedAttributes' => true,
+         'http://refeds.org/category/research-and-scholarship' => array(
+             'urn:oid:2.16.840.1.113730.3.1.241', #displayName
+             'urn:oid:2.5.4.4', #sn
+             'urn:oid:2.5.4.42', #givenName
+             'urn:oid:0.9.2342.19200300.100.1.3', #mail
+             'urn:oid:1.3.6.1.4.1.5923.1.1.1.6', #eduPersonPrincipalName
+             'urn:oid:1.3.6.1.4.1.5923.1.1.1.9', #eduPersonScopedAffiliation
+         ),
+    ),
+```
+
+The following example implements the following logic:
+
+1. Attributes requested in metadata are released to SP's having the `urn:x-myfederation:entities`
+and [GÉANT Data Protection Code of Conduct](http://www.geant.net/uri/dataprotection-code-of-conduct/v1)
+entity categories.
+2. The Research & Scholarship entity category attribute bundle is released to R&S SP's, but the
+list of attributes can be extended, if the SP has additional attribute requirements in metadata.
+3. No attributes are released to any other SP's.
+
+```
+    50  => array(
+         'class' => 'entitycategories:EntityCategory',
+         'default' => true,
+         'strict' => true,
+         'allowRequestedAttributes' => true,
+         'urn:x-myfederation:entities' => array (),
+         'http://www.geant.net/uri/dataprotection-code-of-conduct/v1' => array (),
+         'http://refeds.org/category/research-and-scholarship' => array(
+             'urn:oid:2.16.840.1.113730.3.1.241', #displayName
+             'urn:oid:2.5.4.4', #sn
+             'urn:oid:2.5.4.42', #givenName
+             'urn:oid:0.9.2342.19200300.100.1.3', #mail
+             'urn:oid:1.3.6.1.4.1.5923.1.1.1.6', #eduPersonPrincipalName
+             'urn:oid:1.3.6.1.4.1.5923.1.1.1.9', #eduPersonScopedAffiliation
+         ),
+    ),
+```
+
+You may want to release some attributes to SP's based on bilateral agreements rather than metadata. There
+is a[modified version of core:AttributeLimit](https://github.com/NIIF/simplesamlphp-module-attributelimit)
+module available that makes it possible to *add* certain attributes to some listed SP's, as presented in
+the next example:
+
+```
+    51 => array(
+        'class' => 'niif:AttributeLimit',
+        'default' => true,
+        'bilateralSPs' => array(
+            'google.com' => array('mail'),
+            'urn:federation:MicrosoftOnline' => array('IDPEmail', 'ImmutableID'),
+         ),
+    ),
+```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 Entity Categories
 =================
 
-This is a SimpleSAMLphp module to create attribute release policies based on entity categories. It allows the
-modification _on the fly_ of the attributes requested by a service (both removing and adding attributes) depending on
-the entity category or categories that the service is declared to belong to.
+This is a SimpleSAMLphp module to create attribute release policies based on entity categories. It allows the modification _on the fly_ of the attributes requested by a service (both removing and adding attributes) depending on the entity category or categories that the service is declared to belong to.
 
-Please note that **this module is not a replacement for the _core:AttributeLimit_ authentication processing filter**. It
-will only modify the attributes requested by a service, and therefore it should be used together with the aforementioned
-_core:AttributeLimit_ filter or any other filter that provides a similar functionality.
+Please note that **this module is not a replacement for the _core:AttributeLimit_ authentication processing filter**. It will only modify the attributes requested by a service, and therefore it should be used together with the aforementioned _core:AttributeLimit_ filter or any other filter that provides a similar functionality.
 
 Installation
 ------------
@@ -19,35 +15,22 @@ command in the root of your SimpleSAMLphp installation:
 composer.phar require simplesamlphp/simplesamlphp-module-entitycategories:dev-master
 ```
 
-where `dev-master` instructs Composer to install the `master` (**development**) branch from the Git repository. See the
-[releases](https://github.com/simplesamlphp/simplesamlphp-module-entitycategories/releases) available if you
-want to use a stable version of the module.
+where `dev-master` instructs Composer to install the `master` (**development**) branch from the Git repository. See the [releases](https://github.com/simplesamlphp/simplesamlphp-module-entitycategories/releases) available if you want to use a stable version of the module.
 
 Configuration
 -------------
 
-This module includes an authentication processing filter that can be configured as any other filter. Please read
-[the documentation](https://simplesamlphp.org/docs/stable/simplesamlphp-authproc) for more general information about
-authentication processing filters.
+This module includes an authentication processing filter that can be configured as any other filter. Please read [the documentation](https://simplesamlphp.org/docs/stable/simplesamlphp-authproc) for more general information about authentication processing filters.
 
-You can define your own entity categories, and assign the attributes allowed for each of them. It accepts the following
-boolean configuration options:
+You can define your own entity categories, and assign the attributes allowed for each of them. It accepts the following boolean configuration options:
 
-* `default` (defaults to `false`): when set to `true` it indicates that the attributes defined for each category should
-be considered the minimum set for those service providers not specifying any required attributes.
-* `strict` (defaults to `false`): when this option is `true` and the a service provider has none of the listed
-entity categories, the module will zero out the list of releasable attributes to it. If set to `false`, the
-releasable attribute list will remain unchanged for non-matching service providers.
-* `allowRequestedAttributes` (defaults to `false`): if set to `true` the list of requested attributes in the SP metadata
-will be added to the list of allowed attributes in the entity category configuration. If `false`, the attribute
-requirements from the metadata (ie. RequestedAttributes) are ignored during the attribute release for the service
-providers that match one of the entity categories.
+* `default` (defaults to `false`): when set to `true` it indicates that the attributes defined for each category should be considered the minimum set for those service providers not specifying any required attributes.
+* `strict` (defaults to `false`): when this option is `true` and the a service provider has none of the listed entity categories, the module will zero out the list of releasable attributes to it. If set to `false`, the releasable attribute list will remain unchanged for non-matching service providers.
+* `allowRequestedAttributes` (defaults to `false`): if set to `true` the list of requested attributes in the SP metadata will be added to the list of allowed attributes in the entity category configuration. If `false`, the attribute requirements from the metadata (ie. RequestedAttributes) are ignored during the attribute release for the service providers that match one of the entity categories.
 
-The rest of the configuration would be `category => attributes` pairs, where *category* is the identifier of the
-entity category, and *attributes* is an array containing a list of attributes allowed for that category.
+The rest of the configuration would be `category => attributes` pairs, where *category* is the identifier of the entity category, and *attributes* is an array containing a list of attributes allowed for that category.
 
-For example, to allow all the services in your domain to receive *eduPersonPrincipalName* as an identifier of the user,
-tag them all with a custom category, and define the following filter:
+For example, to allow all the services in your domain to receive *eduPersonPrincipalName* as an identifier of the user, tag them all with a custom category, and define the following filter:
 ```
     50 => array(
         'class' => 'entitycategories:EntityCategory',
@@ -58,8 +41,7 @@ tag them all with a custom category, and define the following filter:
     ),
 ```
 
-Now, all the services with the following fragment in their metadata are guaranteed to receive *eduPersonPrincipalName*
-in case they ask for it or they don't ask for any attributes at all:
+Now, all the services with the following fragment in their metadata are guaranteed to receive *eduPersonPrincipalName* in case they ask for it or they don't ask for any attributes at all:
 
 ```
     'EntityAttributes' => array(
@@ -69,10 +51,7 @@ in case they ask for it or they don't ask for any attributes at all:
     ),
 ```
 
-Please note that if the service asks for other attributes, not including *eduPersonPrincipalName*, **that attribute will
-not be sent**. If the service asks for some attributes but not *eduPersonPrincipalName*, **no attributes** will be sent.
-Also remember that this filter must be used together with `core:AttributeLimit` or a similar filter. Therefore, after
-configuring the `entitycategories:EntityCategory` filter, you should also configure the former:
+Please note that if the service asks for other attributes, not including *eduPersonPrincipalName*, **that attribute will not be sent**. If the service asks for some attributes but not *eduPersonPrincipalName*, **no attributes** will be sent. Also remember that this filter must be used together with `core:AttributeLimit` or a similar filter. Therefore, after configuring the `entitycategories:EntityCategory` filter, you should also configure the former:
 
 ```
     51 => array(
@@ -81,12 +60,9 @@ configuring the `entitycategories:EntityCategory` filter, you should also config
     ),
 ```
 
-This will deny all attributes by default, but let the configuration of each service to override that limitation. Notice
-the indexes used for each filter. Filters are evaluated in order based on their indexes, so the filters defined in this
-module should have a lower index than the one assigned to `core:AttributeLimit`.
+This will deny all attributes by default, but let the configuration of each service to override that limitation. Notice the indexes used for each filter. Filters are evaluated in order based on their indexes, so the filters defined in this module should have a lower index than the one assigned to `core:AttributeLimit`.
 
-Now, if you just want to allow certain attributes to be sent to a service of a specific category, but don't want to send
-them in case the service doesn't ask for them, skip the `default` configuration option or set it to `false`:
+Now, if you just want to allow certain attributes to be sent to a service of a specific category, but don't want to send them in case the service doesn't ask for them, skip the `default` configuration option or set it to `false`:
 
 ```
     50 => array(
@@ -97,14 +73,9 @@ them in case the service doesn't ask for them, skip the `default` configuration 
     ),
 ```
 
-Now, if a service belonging to the `urn:something:local_service` category requests the *eduPersonPrincipalName*
-attribute in the `attributes` array on its metadata, it is guaranteed to get it. If it doesn't request it (no matter
-whether it requests other attributes or not), it won't get it.
+Now, if a service belonging to the `urn:something:local_service` category requests the *eduPersonPrincipalName* attribute in the `attributes` array on its metadata, it is guaranteed to get it. If it doesn't request it (no matter whether it requests other attributes or not), it won't get it.
 
-The following example will release the attribute bundle defined in
-[Research and Scholarship Entity Category](https://refeds.org/category/research-and-scholarship) for SP's having
-the R&S entity category, but also the released set may be extended by additional attributes. For non-matching SP's,
-the the release rules are controlled by the metadata.
+The following example will release the attribute bundle defined in [Research and Scholarship Entity Category](https://refeds.org/category/research-and-scholarship) for SP's having the R&S entity category, but also the released set may be extended by additional attributes. For non-matching SP's, the the release rules are controlled by the metadata.
 
 ```
     50  => array(
@@ -125,11 +96,8 @@ the the release rules are controlled by the metadata.
 
 The following example implements the following logic:
 
-1. Attributes requested in metadata are released to SP's having the `urn:x-myfederation:entities`
-and [GÉANT Data Protection Code of Conduct](http://www.geant.net/uri/dataprotection-code-of-conduct/v1)
-entity categories.
-2. The Research & Scholarship entity category attribute bundle is released to R&S SP's, but the
-list of attributes can be extended, if the SP has additional attribute requirements in metadata.
+1. Attributes requested in metadata are released to SP's having the `urn:x-myfederation:entities` and [GÉANT Data Protection Code of Conduct](http://www.geant.net/uri/dataprotection-code-of-conduct/v1) entity categories.
+2. The Research & Scholarship entity category attribute bundle is released to R&S SP's, but the list of attributes can be extended, if the SP has additional attribute requirements in metadata.
 3. No attributes are released to any other SP's.
 
 ```
@@ -151,10 +119,7 @@ list of attributes can be extended, if the SP has additional attribute requireme
     ),
 ```
 
-You may want to release some attributes to SP's based on bilateral agreements rather than metadata. There
-is a[modified version of core:AttributeLimit](https://github.com/NIIF/simplesamlphp-module-attributelimit)
-module available that makes it possible to *add* certain attributes to some listed SP's, as presented in
-the next example:
+You may want to release some attributes to SP's based on bilateral agreements rather than metadata. There is a [modified version of core:AttributeLimit](https://github.com/NIIF/simplesamlphp-module-attributelimit) module available that makes it possible to *add* certain attributes to some listed SP's, as presented in the next example:
 
 ```
     51 => array(

--- a/lib/Auth/Process/EntityCategory.php
+++ b/lib/Auth/Process/EntityCategory.php
@@ -28,6 +28,23 @@ class sspmod_entitycategories_Auth_Process_EntityCategory extends SimpleSAML_Aut
      */
     protected $default = false;
 
+    /**
+     *
+     * Whether it is allowed to release attributes to entities having unknown entity category based on requested attributes.
+     * Strict means not to release attributes to that entities. If strict is false, attributeLimit will do the filtering.
+     *
+     * @var bool
+     */
+    protected $strict = true;
+
+    /**
+     *
+     * Whether it is allowed to release additional requested attributes than configured in the list of the configuration of the entity category.
+     *
+     * @var bool
+     */
+    protected $allowRequestedAttributes = false;
+
 
     /**
      * EntityCategory constructor.
@@ -48,6 +65,26 @@ class sspmod_entitycategories_Auth_Process_EntityCategory extends SimpleSAML_Aut
                     );
                 }
                 $this->default = $value;
+                continue;
+            }
+
+            if ($index === 'strict') {
+                if (!is_bool($value)) {
+                    throw new \SimpleSAML\Error\ConfigurationError(
+                        "The 'strict' configuration option must have a boolean value."
+                    );
+                }
+                $this->strict = $value;
+                continue;
+            }
+
+            if ($index === 'allowRequestedAttributes') {
+                if (!is_bool($value)) {
+                    throw new \SimpleSAML\Error\ConfigurationError(
+                        "The 'allowRequestedAttributes' configuration option must have a boolean value."
+                    );
+                }
+                $this->allowRequestedAttributes = $value;
                 continue;
             }
 
@@ -117,13 +154,13 @@ class sspmod_entitycategories_Auth_Process_EntityCategory extends SimpleSAML_Aut
                     continue;
                 }
 
-                if (in_array($attrname, $this->categories[$category])) {
+                if (in_array($attrname, $this->categories[$category]) || $this->allowRequestedAttributes) {
                     $found = true;
                     break;
                 }
             }
 
-            if (!$found) {
+            if (!$found && $this->strict) {
                 // no category (if any) allows the attribute, so remove it
                 unset($request['Destination']['attributes'][$index]);
             }

--- a/lib/Auth/Process/EntityCategory.php
+++ b/lib/Auth/Process/EntityCategory.php
@@ -113,7 +113,7 @@ class sspmod_entitycategories_Auth_Process_EntityCategory extends SimpleSAML_Aut
     public function process(&$request)
     {
         if (!array_key_exists('EntityAttributes', $request['Destination'])) {
-            if ($strict) {
+            if ($this->strict) {
                 // We do not allow to release any attribute to entity having no entity attribute
                 $request['Destination']['attributes'] = array();
             }
@@ -121,7 +121,7 @@ class sspmod_entitycategories_Auth_Process_EntityCategory extends SimpleSAML_Aut
         }
 
         if (!array_key_exists('http://macedir.org/entity-category', $request['Destination']['EntityAttributes'])) {
-            if ($strict) {
+            if ($this->strict) {
                 // We do not allow to release any attribute to entity having no entity category
                 $request['Destination']['attributes'] = array();
             }

--- a/lib/Auth/Process/EntityCategory.php
+++ b/lib/Auth/Process/EntityCategory.php
@@ -1,8 +1,5 @@
 <?php
 
-namespace SimpleSAML\Module\entitycategories\Auth\Process;
-
-
 /**
  * An authentication processing filter that modifies the list of attributes sent to a service depending on the entity
  * categories it belongs to. This filter DOES NOT alter the list of attributes sent itself, but modifies the list of
@@ -12,7 +9,7 @@ namespace SimpleSAML\Module\entitycategories\Auth\Process;
  * @author Jaime Pérez Crespo, UNINETT AS <jaime.perez@uninett.no>
  * @package SimpleSAMLphp
  */
-class EntityCategory extends \SimpleSAML_Auth_ProcessingFilter
+class sspmod_entitycategories_Auth_Process_EntityCategory extends SimpleSAML_Auth_ProcessingFilter
 {
 
     /**


### PR DESCRIPTION
We have implemented two addtional options for the module:

* `strict`: if false, it allows to release attributes to entities having no, or unknown entity category, based on requested attributes
* `allowRequestedAttributes`: allow to release additional requested attributes than configured in the list of the configuration of an entity category

Default values are set that these options do not change the default behave of the module. More details and examples are in the README. With these options it is much easier to configure complex rules based on entity categories and requested attributes.

We in eduID.hu use our version of this modul in production without any issue.