### PR TITLE
Fix message for the assertion

### DIFF
--- a/src/Auth/Process/EntityCategory.php
+++ b/src/Auth/Process/EntityCategory.php
@@ -104,7 +104,7 @@ class EntityCategory extends Auth\ProcessingFilter
 
             Assert::string(
                 $index,
-                "Unspecified allowed attributes for the '$value' category.",
+                "Identifier of a category must be a string. '$index' is set.",
                 Error\ConfigurationError::class,
             );
 


### PR DESCRIPTION
The message of this exception must contain the value if the `$index`, not the `$value`.